### PR TITLE
fixed problem with data-method in IE7,8

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -172,7 +172,7 @@ YUI().use('node-base', 'node-event-delegate', 'selector-css3', 'io-form', 'rails
 	 */
 
 	function insertHiddenField(form, name, value) {
-		form.insert(Y.Node.create('<input/>').setAttrs({ type: 'hidden', name: name, value: value }));
+		form.insert(Y.Node.create(Y.Lang.sub('<input type="{type}" name="{name}" value="{value}"/>', {type:'hidden', name: name, value: value })));
 	}
 
 	function handleMethod(e) {
@@ -181,6 +181,8 @@ YUI().use('node-base', 'node-event-delegate', 'selector-css3', 'io-form', 'rails
 			url = element.get('href'),
 			csrfParam = Y.one('meta[name=csrf-param]'),
 			csrfToken = Y.one('meta[name=csrf-token]');
+			
+		if (element.getAttribute('data-remote')) return; // work-around for IE7,8 problem with :not([data-remote]) on delegate
 		
 		var form = Y.Node.create('<form method="POST" style="display:none"></form>').setAttribute('action', url);
 		element.get('parentNode').insert(form);
@@ -195,7 +197,7 @@ YUI().use('node-base', 'node-event-delegate', 'selector-css3', 'io-form', 'rails
 		e.preventDefault();
 	}
 	 
-	doc.delegate('click', handleMethod, 'a[data-method]:not([data-remote])');
+	doc.delegate('click', handleMethod, 'a[data-method]');
 
 
 	/**


### PR DESCRIPTION
IE7,8 were still problematic with data-method on links (I was testing in IE9 in IE8 and IE7 emulation mode).  The problem seems to be that the YUI3 Node method .setAttrs was not working for legacy versions of IE when the node was not appended to the DOM yet.  To get around this I removed the setAttrs method and just included the attributes in the string parameter to the Y.Node.create method.  I am using YUI 3.4, but I recall running into this issue in other projects... I think this is just a quirk of old IE, not necessarily YUI's fault.  Again, I wasn't testing in IE7,8 proper, but in IE9 with legacy emulation.

Also, despite the proper inclusion of the css3-selector module, legacy versions of IE still were still not obeying the :not css selector.  The work-around I needed included taking out the :not part of the selector and immediately returning from the function if data-remote attribute found.  Please take a look at the few lines of changes in the diff, and please consider a merge. Thanks!
